### PR TITLE
NEXUS-18829: Maven Staging Plugin: user readable tag generation multi-module handling

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -100,6 +100,7 @@ public class StagingDeployMojo
   private String getProvidedOrGeneratedTag() {
     if (tag == null || tag.isEmpty()) {
       String generatedTag = tagGenerator.generate(artifact.getArtifactId(), artifact.getBaseVersion());
+      getMavenSession().getUserProperties().setProperty("tag", generatedTag);
       getLog().info(String.format("No tag was provided; using generated tag '%s'", generatedTag));
       return generatedTag;
     }

--- a/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
+++ b/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import com.sonatype.nexus.api.common.ServerConfig;
 import com.sonatype.nexus.api.repository.v3.Asset;
@@ -115,11 +116,13 @@ public class StagingDeployMojoTest
   @Mock
   private RepositoryManagerV3Client client;
 
+  private Path tempDirectory;
+
   private Server server;
 
-  private StagingDeployMojo underTest;
+  private Properties userProperties;
 
-  private Path tempDirectory;
+  private StagingDeployMojo underTest;
 
   @Before
   public void setup() throws Exception {
@@ -187,6 +190,7 @@ public class StagingDeployMojoTest
     underTest.execute();
 
     verify(client).createTag(GENERATED_TAG);
+    assertThat(userProperties.getProperty("tag"), equalTo(GENERATED_TAG));
   }
 
   @Test
@@ -334,9 +338,13 @@ public class StagingDeployMojoTest
     server.setUsername(USERNAME);
     server.setPassword(PASSWORD);
 
+    userProperties = new Properties();
+
     when(session.getExecutionRootDirectory()).thenReturn(tempDirectory.toString());
 
     when(session.getSettings()).thenReturn(settings);
+
+    when(session.getUserProperties()).thenReturn(userProperties);
 
     when(settings.getServer(anyString())).thenReturn(server);
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/NEXUS-18829

This PR is to properly handle tag generation for multi-module projects when a tag is not specified by a user. Before this fix, each module would end up with a different tag instead of using the same tag for all modules in the project.