### PR TITLE
Always add required pom as asset.

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.maven.staging;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +29,6 @@ import com.sonatype.nexus.api.repository.v3.Tag;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;

--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -190,7 +190,7 @@ public class StagingDeployMojo
     File file = artifact.getFile();
 
     if (pomProject) {
-      getLog().info("Prom project to deploy, deploying with attached artifacts.");
+      getLog().info("Pom project to deploy, deploying with attached artifacts.");
     }
     else if (file != null && file.isFile()) {
       deployables.add(artifact);

--- a/testsuite/src/test/java/org/sonatype/nexus/maven/staging/mojo/StagingDeployIT.java
+++ b/testsuite/src/test/java/org/sonatype/nexus/maven/staging/mojo/StagingDeployIT.java
@@ -82,8 +82,13 @@ public class StagingDeployIT
     verifier.executeGoals(goals);
 
     verifyComponent(RELEASE_REPOSITORY, groupId, artifactId, version, tag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, groupId, artifactId, version);
+
     verifyComponent(RELEASE_REPOSITORY, groupId, artifactId + "-module1", version, tag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, groupId, artifactId + "-module1", version);
+
     verifyComponent(RELEASE_REPOSITORY, groupId, artifactId + "-module2", version, tag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, groupId, artifactId + "-module2", version);
   }
 
   @Test
@@ -167,8 +172,13 @@ public class StagingDeployIT
     assertThat(generatedTag, startsWith(artifactId + "-" + VERSION + "-"));
 
     verifyComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId, VERSION, generatedTag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId, VERSION);
+
     verifyComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId + "-module1", VERSION, generatedTag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId + "-module1", VERSION);
+
     verifyComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId + "-module2", VERSION, generatedTag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, GROUP_ID, artifactId + "-module2", VERSION);
   }
 
   @Test
@@ -342,6 +352,7 @@ public class StagingDeployIT
     verifier.executeGoals(goals);
 
     verifyComponent(RELEASE_REPOSITORY, groupId, artifactId, version, tag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, groupId, artifactId, version);
   }
 
   private File getPropertiesFile(final File projectDir) {


### PR DESCRIPTION
JIRA: https://issues.sonatype.org/browse/NEXUS-20029
CI: https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/nxrm3-maven-plugin-feature/job/NEXUS-20029-always-add-required-pom/1/ ![image](https://user-images.githubusercontent.com/3211896/71487578-06907500-27d1-11ea-9f30-dde55da96a2c.png)

We failed to add the *pom.xml* as required at all uploads. The *nexus-staging* plugin did do this, although admittedly it did this at a later point by reading the the metadata and then adding it for upload. We don't use the same underlying mechanism (i.e. the maven plugin) that does the read of the metadata and attach the pom for upload and this was thus was easily missed.