### PR TITLE
Assure we use the correct extensions from artifacts for assets

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -161,7 +161,8 @@ public class StagingDeployMojo
 
         DefaultAsset asset = new DefaultAsset(deployableArtifact.getFile().getName(), stream);
 
-        asset.addAttribute("extension", deployableArtifact.getType());
+        // NEXUS-22246 - just like the maven class DefaultArtifactDeployer use the ArtifactHandler#getExtension()
+        asset.addAttribute("extension", deployableArtifact.getArtifactHandler().getExtension());
 
         if (deployableArtifact.getClassifier() != null) {
           asset.addAttribute("classifier", deployableArtifact.getClassifier());

--- a/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
+++ b/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
@@ -31,6 +31,7 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -109,6 +110,9 @@ public class StagingDeployMojoTest
 
   @Mock
   private Artifact artifact, attachedArtifact;
+
+  @Mock
+  private ArtifactHandler artifactHandler;
 
   @Mock
   private TagGenerator tagGenerator;
@@ -390,6 +394,8 @@ public class StagingDeployMojoTest
     when(artifact.getBaseVersion()).thenReturn(VERSION);
     when(artifact.getFile()).thenReturn(getPom());
     when(artifact.getType()).thenReturn(EXTENSION);
+    when(artifact.getArtifactHandler()).thenReturn(artifactHandler);
+    when(artifactHandler.getExtension()).thenReturn(EXTENSION);
     when(artifact.getClassifier()).thenReturn(CLASSIFIER);
   }
 }

--- a/testsuite/src/test/java/org/sonatype/nexus/maven/staging/mojo/StagingDeployIT.java
+++ b/testsuite/src/test/java/org/sonatype/nexus/maven/staging/mojo/StagingDeployIT.java
@@ -188,9 +188,16 @@ public class StagingDeployIT
     List<String> goals = new ArrayList<>();
 
     goals.add("javadoc:jar");
+    goals.add("source:jar");
     goals.add(STAGING_DEPLOY);
 
-    assertStagingWithDeployGoal(goals, tag);
+    ComponentItem componentItem = assertStagingWithDeployGoal(goals, tag);
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "javadoc.jar");
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "javadoc.jar.md5");
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "javadoc.jar.sha1");
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "sources.jar");
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "sources.jar.md5");
+    verifyAssetForComponent(RELEASE_REPOSITORY, componentItem, "sources.jar.sha1");
   }
 
   @Test
@@ -318,17 +325,17 @@ public class StagingDeployIT
     assertStagingWithDeployGoal(goals, tag);
   }
 
-  private void assertStagingWithDeployGoal(final List<String> goals,
-                                           final String tag) throws Exception
+  private ComponentItem assertStagingWithDeployGoal(final List<String> goals,
+                                                    final String tag) throws Exception
   {
     initialiseVerifier(projectDir);
 
-    assertStagingWithDeployGoal(goals, tag, JAR_PACKAGING);
+    return assertStagingWithDeployGoal(goals, tag, JAR_PACKAGING);
   }
 
-  private void assertStagingWithDeployGoal(final List<String> goals,
-                                           final String tag,
-                                           final String packaging) throws Exception
+  private ComponentItem assertStagingWithDeployGoal(final List<String> goals,
+                                                    final String tag,
+                                                    final String packaging) throws Exception
   {
     String groupId = GROUP_ID;
     String artifactId = randomUUID().toString();
@@ -336,14 +343,14 @@ public class StagingDeployIT
 
     createProject(projectDir, RELEASE_REPOSITORY, groupId, artifactId, version);
 
-    deployAndVerify(goals, tag, groupId, artifactId, version);
+    return deployAndVerify(goals, tag, groupId, artifactId, version);
   }
 
-  private void deployAndVerify(final List<String> goals,
-                               final String tag,
-                               final String groupId,
-                               final String artifactId,
-                               final String version) throws VerificationException
+  private ComponentItem deployAndVerify(final List<String> goals,
+                                        final String tag,
+                                        final String groupId,
+                                        final String artifactId,
+                                        final String version) throws VerificationException
   {
     verifier.setDebug(true);
 
@@ -351,8 +358,10 @@ public class StagingDeployIT
 
     verifier.executeGoals(goals);
 
-    verifyComponent(RELEASE_REPOSITORY, groupId, artifactId, version, tag);
-    verifyPomAssetForComponent(RELEASE_REPOSITORY, groupId, artifactId, version);
+    ComponentItem componentItem = verifyComponent(RELEASE_REPOSITORY, groupId, artifactId, version, tag);
+    verifyPomAssetForComponent(RELEASE_REPOSITORY, componentItem.group, componentItem.name, componentItem.version);
+
+    return componentItem;
   }
 
   private File getPropertiesFile(final File projectDir) {


### PR DESCRIPTION
JIRA: https://issues.sonatype.org/browse/NEXUS-22246
CI: https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/nxrm3-maven-plugin-feature/job/NEXUS-22246-use-correct-extensions/1/ ![image](https://user-images.githubusercontent.com/3211896/71534741-b808d680-28b5-11ea-96f9-00c0926e256c.png)


We unfortunately didn't use the correct way of setting the extensions and now have corrected this by using the same way as [DefaultArtifactDeployer](https://github.com/apache/maven/blob/master/maven-compat/src/main/java/org/apache/maven/artifact/deployer/DefaultArtifactDeployer.java#L76) is doing by utilizing `artifact.getArtifactHandler().getExtension();`