### PR TITLE
NEXUS-29515 - add support for snapshot target selection

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -51,6 +51,9 @@ public class StagingDeployMojo
   @Parameter(property = "repository", required = true)
   private String repository;
 
+  @Parameter(property = "snapshotRepository")
+  private String snapshotRepository;
+
   @Parameter(property = "tag")
   private String tag;
 
@@ -95,13 +98,20 @@ public class StagingDeployMojo
 
     failIfOffline();
 
+    String repository;
+    if (artifact.isSnapshot() && snapshotRepository != null && !snapshotRepository.trim().isEmpty()) {
+      repository = snapshotRepository;
+    } else {
+      repository = this.repository;
+    }
+
     List<Artifact> deployables = prepareDeployables();
 
     try {
       tag = getProvidedOrGeneratedTag();
       maybeCreateTag(client, tag);
       getLog().info(String.format("Deploying to repository '%s' with tag '%s'", repository, tag));
-      doUpload(client, deployables, tag);
+      doUpload(client, repository, deployables, tag);
     }
     catch (MojoExecutionException e) {
       throw e;
@@ -147,6 +157,7 @@ public class StagingDeployMojo
   }
 
   private void doUpload(final RepositoryManagerV3Client client,
+                        final String repository,
                         final List<Artifact> deployables,
                         final String tag) throws Exception
   {
@@ -259,5 +270,10 @@ public class StagingDeployMojo
   @VisibleForTesting
   void setTagGenerator(final TagGenerator tagGenerator) {
     this.tagGenerator = tagGenerator;
+  }
+
+  @VisibleForTesting
+  void setSnapshotRepository(String snapshotRepository) {
+    this.snapshotRepository = snapshotRepository;
   }
 }

--- a/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
+++ b/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
@@ -89,6 +89,8 @@ public class StagingDeployMojoTest
 
   private static final String REPOSITORY = "maven-releases";
 
+  private static final String SNAPSHOT_REPOSITORY = "maven-snapshots";
+
   private static final String ARTIFACT_ID_KEY = "artifactId";
 
   private static final String GROUP_ID_KEY = "groupId";
@@ -225,6 +227,109 @@ public class StagingDeployMojoTest
     ArgumentCaptor<Component> componentArgumentCaptor = ArgumentCaptor.forClass(Component.class);
 
     verify(client).upload(eq(REPOSITORY), componentArgumentCaptor.capture(), eq(TAG));
+
+    Component component = componentArgumentCaptor.getValue();
+
+    Map<String, String> attributes = component.getAttributes();
+    assertThat(attributes.get(ARTIFACT_ID_KEY), is(equalTo(ARTIFACT_ID)));
+    assertThat(attributes.get(GROUP_ID_KEY), is(equalTo(GROUP_ID)));
+    assertThat(attributes.get(VERSION_KEY), is(equalTo(VERSION)));
+
+    Collection<Asset> assets = component.getAssets();
+    assertThat(assets.size(), is(equalTo(3)));
+
+    // check pom asset
+    List<Asset> pomAssets = assets.stream().filter(this::isPomAsset).collect(toList());
+    assertThat(pomAssets.size(), is(equalTo(1)));
+    assertThat(pomAssets.get(0).getFilename(), is(equalTo(getPom().getName())));
+    assertThat(pomAssets.get(0).getData(), notNullValue());
+
+    // check all other assets
+    for (Asset asset : assets.stream().filter(asset -> !isPomAsset(asset)).collect(toList())) {
+      Map<String, String> assetAttributes = asset.getAttributes();
+      assertThat(assetAttributes.get(EXTENSION_KEY), is(equalTo(EXTENSION)));
+      assertThat(assetAttributes.get(CLASSIFIER_KEY), is(equalTo(CLASSIFIER)));
+    }
+  }
+
+  @Test
+  public void uploadReleaseWithSnapshotConfigured() throws Exception {
+    underTest.setSnapshotRepository(SNAPSHOT_REPOSITORY);
+
+    underTest.execute();
+
+    ArgumentCaptor<Component> componentArgumentCaptor = ArgumentCaptor.forClass(Component.class);
+
+    verify(client).upload(eq(REPOSITORY), componentArgumentCaptor.capture(), eq(TAG));
+
+    Component component = componentArgumentCaptor.getValue();
+
+    Map<String, String> attributes = component.getAttributes();
+    assertThat(attributes.get(ARTIFACT_ID_KEY), is(equalTo(ARTIFACT_ID)));
+    assertThat(attributes.get(GROUP_ID_KEY), is(equalTo(GROUP_ID)));
+    assertThat(attributes.get(VERSION_KEY), is(equalTo(VERSION)));
+
+    Collection<Asset> assets = component.getAssets();
+    assertThat(assets.size(), is(equalTo(3)));
+
+    // check pom asset
+    List<Asset> pomAssets = assets.stream().filter(this::isPomAsset).collect(toList());
+    assertThat(pomAssets.size(), is(equalTo(1)));
+    assertThat(pomAssets.get(0).getFilename(), is(equalTo(getPom().getName())));
+    assertThat(pomAssets.get(0).getData(), notNullValue());
+
+    // check all other assets
+    for (Asset asset : assets.stream().filter(asset -> !isPomAsset(asset)).collect(toList())) {
+      Map<String, String> assetAttributes = asset.getAttributes();
+      assertThat(assetAttributes.get(EXTENSION_KEY), is(equalTo(EXTENSION)));
+      assertThat(assetAttributes.get(CLASSIFIER_KEY), is(equalTo(CLASSIFIER)));
+    }
+  }
+
+  @Test
+  public void uploadSnapshotSameDestination() throws Exception {
+    when(artifact.isSnapshot()).thenReturn(true);
+
+    underTest.execute();
+
+    ArgumentCaptor<Component> componentArgumentCaptor = ArgumentCaptor.forClass(Component.class);
+
+    verify(client).upload(eq(REPOSITORY), componentArgumentCaptor.capture(), eq(TAG));
+
+    Component component = componentArgumentCaptor.getValue();
+
+    Map<String, String> attributes = component.getAttributes();
+    assertThat(attributes.get(ARTIFACT_ID_KEY), is(equalTo(ARTIFACT_ID)));
+    assertThat(attributes.get(GROUP_ID_KEY), is(equalTo(GROUP_ID)));
+    assertThat(attributes.get(VERSION_KEY), is(equalTo(VERSION)));
+
+    Collection<Asset> assets = component.getAssets();
+    assertThat(assets.size(), is(equalTo(3)));
+
+    // check pom asset
+    List<Asset> pomAssets = assets.stream().filter(this::isPomAsset).collect(toList());
+    assertThat(pomAssets.size(), is(equalTo(1)));
+    assertThat(pomAssets.get(0).getFilename(), is(equalTo(getPom().getName())));
+    assertThat(pomAssets.get(0).getData(), notNullValue());
+
+    // check all other assets
+    for (Asset asset : assets.stream().filter(asset -> !isPomAsset(asset)).collect(toList())) {
+      Map<String, String> assetAttributes = asset.getAttributes();
+      assertThat(assetAttributes.get(EXTENSION_KEY), is(equalTo(EXTENSION)));
+      assertThat(assetAttributes.get(CLASSIFIER_KEY), is(equalTo(CLASSIFIER)));
+    }
+  }
+
+  @Test
+  public void uploadSnapshotDifferentDestination() throws Exception {
+    underTest.setSnapshotRepository(SNAPSHOT_REPOSITORY);
+    when(artifact.isSnapshot()).thenReturn(true);
+
+    underTest.execute();
+
+    ArgumentCaptor<Component> componentArgumentCaptor = ArgumentCaptor.forClass(Component.class);
+
+    verify(client).upload(eq(SNAPSHOT_REPOSITORY), componentArgumentCaptor.capture(), eq(TAG));
 
     Component component = componentArgumentCaptor.getValue();
 


### PR DESCRIPTION
If `snapshotRepository` is defined then snapshots will be sent to that
repository instead, otherwise staging will send to the configured
release repository.