### PR TITLE
build: add IQ maven plugin and configuration for Jenkins build

### DIFF
--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -3,7 +3,7 @@ library('jenkins-shared')
 
 def settings =[
     deployBranch: 'main',
-    performSonarAnalysis: true,
+    performSonarAnalysis: false,
     onSuccess: { build, env ->
       notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')
     },

--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -9,6 +9,11 @@ def settings =[
     },
     onFailure: { build, env ->
       notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')
+    },
+    iqPolicyEvaluation: { stage ->
+      nexusPolicyEvaluation iqStage: stage, iqApplication: 'nxrm3-maven-plugin',
+      iqScanPatterns: [[scanPattern: 'scan_nothing']],
+      iqModuleExcludes: [[moduleExclude: 'testsuite/**']],
     }
 ]
 

--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -13,7 +13,7 @@ def settings =[
     iqPolicyEvaluation: { stage ->
       nexusPolicyEvaluation iqStage: stage, iqApplication: 'nxrm3-maven-plugin',
         iqScanPatterns: [[scanPattern: 'scan_nothing']],
-        iqModuleExcludes: [[moduleExclude: 'testsuite/**']],
+        iqModuleExcludes: [[moduleExclude: 'testsuite/**']]
     }
 ]
 

--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -12,9 +12,9 @@ def settings =[
     },
     iqPolicyEvaluation: { stage ->
       nexusPolicyEvaluation iqStage: stage, iqApplication: 'nxrm3-maven-plugin',
-      iqScanPatterns: [[scanPattern: 'scan_nothing']],
-      iqModuleExcludes: [[moduleExclude: 'testsuite/**']],
-    },
+        iqScanPatterns: [[scanPattern: 'scan_nothing']],
+        iqModuleExcludes: [[moduleExclude: 'testsuite/**']],
+    }
 ]
 
 mavenSnapshotPipeline(settings)

--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -14,7 +14,7 @@ def settings =[
       nexusPolicyEvaluation iqStage: stage, iqApplication: 'nxrm3-maven-plugin',
       iqScanPatterns: [[scanPattern: 'scan_nothing']],
       iqModuleExcludes: [[moduleExclude: 'testsuite/**']],
-    }
+    },
 ]
 
 mavenSnapshotPipeline(settings)

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -32,7 +32,11 @@
   <description>
     Provides support to access functionality in a remote Nexus Professional server.
   </description>
-  
+
+  <properties>
+    <clm.skip>false</clm.skip>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.version>3.5.2</maven.version>
     <maven.plugin.annotations.version>3.5.1</maven.plugin.annotations.version>
+
+    <clm.applicationId>nxrm3-maven-plugin</clm.applicationId>
+    <clm.skip>true</clm.skip>
   </properties>
 
   <modules>
@@ -158,7 +161,29 @@
           <artifactId>maven-gpg-plugin</artifactId>
           <version>3.0.1</version>
         </plugin>
+        <plugin>
+          <groupId>com.sonatype.clm</groupId>
+          <artifactId>clm-maven-plugin</artifactId>
+          <version>2.16.0-01</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>com.sonatype.clm</groupId>
+        <artifactId>clm-maven-plugin</artifactId>
+        <configuration>
+          <skip>${clm.skip}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Supports two modes generating an IQ evaluation:

* via `mvn clm:evaluate -pl :nxrm3-maven-plugin -Dclm.stage=develop`
* via the feature-snapshot builds in Jenkins