### PR TITLE
Handle artifacts with empty classifiers

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingDeployMojo.java
@@ -327,7 +327,7 @@ public class StagingDeployMojo
         // NEXUS-22246 - just like the maven class DefaultArtifactDeployer use the ArtifactHandler#getExtension()
         asset.addAttribute("extension", deployableArtifact.getArtifactHandler().getExtension());
 
-        if (deployableArtifact.getClassifier() != null) {
+        if (deployableArtifact.getClassifier() != null && !deployableArtifact.getClassifier().isEmpty()) {
           asset.addAttribute("classifier", deployableArtifact.getClassifier());
         }
         component.addAsset(asset);

--- a/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingUploadMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/StagingUploadMojo.java
@@ -311,7 +311,7 @@ public class StagingUploadMojo
       // NEXUS-22246 - just like the maven class DefaultArtifactDeployer use the ArtifactHandler#getExtension()
       asset.addAttribute("extension", deployableArtifact.getArtifactHandler().getExtension());
 
-      if (deployableArtifact.getClassifier() != null) {
+      if (deployableArtifact.getClassifier() != null && !deployableArtifact.getClassifier().isEmpty()) {
         asset.addAttribute("classifier", deployableArtifact.getClassifier());
       }
       component.addAsset(asset);

--- a/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
+++ b/maven-plugin/src/test/java/org/sonatype/nexus/maven/staging/StagingDeployMojoTest.java
@@ -91,6 +91,8 @@ public class StagingDeployMojoTest
 
   private static final String CLASSIFIER = "classifier";
 
+  private static final String EMPTY_CLASSIFIER = "";
+
   private static final String EXTENSION = "extension";
 
   private static final String REPOSITORY = "maven-releases";
@@ -214,6 +216,19 @@ public class StagingDeployMojoTest
 
   @Test
   public void deployToRemote() throws Exception {
+
+    deployToRemoteTest(CLASSIFIER);
+  }
+
+  @Test
+  public void deployToRemoteEmptyClassifier() throws Exception {
+    when(artifact.getClassifier()).thenReturn(EMPTY_CLASSIFIER);
+    when(attachedArtifact.getClassifier()).thenReturn(EMPTY_CLASSIFIER);
+    deployToRemoteTest(null);
+  }
+
+  private void deployToRemoteTest(String expectedClassifier) throws Exception {
+
     underTest.execute();
 
     ArgumentCaptor<Component> componentArgumentCaptor = ArgumentCaptor.forClass(Component.class);
@@ -240,7 +255,7 @@ public class StagingDeployMojoTest
     for (Asset asset : assets.stream().filter(asset -> !isPomAsset(asset)).collect(toList())) {
       Map<String, String> assetAttributes = asset.getAttributes();
       assertThat(assetAttributes.get(EXTENSION_KEY), is(equalTo(EXTENSION)));
-      assertThat(assetAttributes.get(CLASSIFIER_KEY), is(equalTo(CLASSIFIER)));
+      assertThat(assetAttributes.get(CLASSIFIER_KEY), is(equalTo(expectedClassifier)));
     }
   }
 

--- a/maven-plugin/src/test/resources/example.index
+++ b/maven-plugin/src/test/resources/example.index
@@ -15,7 +15,7 @@
     "artifactId": "maven-test-project",
     "version": "1.0",
     "tag": "generatedTag",
-    "classifier": null,
+    "classifier": "",
     "packaging": "pom",
     "extension": "pom",
     "pomFileName": null,


### PR DESCRIPTION
StagingDeployMojo and StagingUploadMojo will fail if they encounter an artifact with an empty string as its classifier, e.g. 

```
Caused by: java.lang.IllegalArgumentException: Attribute value is required
    at com.sonatype.nexus.api.common.ArgumentUtils.checkArgument (SourceFile:33)
    at com.sonatype.nexus.api.common.ArgumentUtils.checkArgument (SourceFile:24)
    at com.sonatype.nexus.api.repository.v3.DefaultAsset.addAttribute (SourceFile:68)
    at org.sonatype.nexus.maven.staging.StagingDeployMojo.doUpload (StagingDeployMojo.java:331)
```

This PR avoids the problem by checking for artifacts with empty classifiers and treating them as if the classifier was null.

It is fairly easy to create artifacts in a build that will fail because of this:

1) Use the maven-assembly-plugin with its 'appendAssemblyId' setting set to 'false'. This will result in an attached artifact with a null classifier.
2) Also use the maven-gpg-plugin. It will see the attached artifact from 1) and will attach an .asc file as another artifact, but instead of using a null classifier it will use an empty string. This artifact will fail staging-deploy or deploy with the failure above.

I believe, but haven't confirmed with a test, that the .index file produced by StagingDeployMojo  with -DstageLocally can include an empty string classifier, which would also fail when read by StagingUploadMojo, with a similar failure to what I saw with StagingDeployMojo.

I filed https://github.com/apache/maven-gpg-plugin/pull/135 with the maven-gpg-plugin to see if they can stop using empty string classifiers in this situation.

In the WildFly ecosystem we have a lot of projects that will hit this as we move to using the nxrm3-maven-plugin.