### PR TITLE
Override maven-enforcer-plugin to allow Maven 3.6.0+ in CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,6 @@ To run the integration tests against a local instance use the profile ```local-n
 
 e.g. ```./mvnw clean install -Plocal-nexus3```
 
-# How to publish to Maven Central
-
-https://sonatype.atlassian.net/wiki/spaces/BNR/pages/388301035/Publishing+Directly+to+Maven+Central
-Steps were added to the jenkinsfile-release to automate this.
-To check if the release was successfully published check https://search.maven.org/artifact/org.sonatype.plugins/nxrm3-maven-plugin
-
-
 # Getting Help
 
 Looking to contribute or need some help?

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <maven.version>3.9.0</maven.version>
+    <maven.version>3.8.6</maven.version>
     <maven.plugin.annotations.version>3.6.4</maven.plugin.annotations.version>
 
     <clm.applicationId>nxrm3-maven-plugin</clm.applicationId>
@@ -201,6 +201,25 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>buildsupport-checkmaven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.6.0,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.sonatype.clm</groupId>
         <artifactId>clm-maven-plugin</artifactId>


### PR DESCRIPTION
Override maven-enforcer-plugin to allow Maven 3.6.0+ in CI builds since it was upgraded the public-parent to 55